### PR TITLE
fix: implement ArrayParameter equals

### DIFF
--- a/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/parameter/ArrayParameter.kt
+++ b/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/parameter/ArrayParameter.kt
@@ -18,4 +18,15 @@ class ArrayParameter<T>(
     override fun set(ps: PreparedStatement, index: Int): Unit =
         throw UnsupportedOperationException("Cannot set PreparedStatement of ${this::class.simpleName}.")
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ArrayParameter<*>
+
+        if (parameters != other.parameters) return false
+
+        return true
+    }
+
 }

--- a/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/parameter/ArrayParameterTest.kt
+++ b/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/parameter/ArrayParameterTest.kt
@@ -1,0 +1,22 @@
+package io.archimedesfw.data.sql.criteria.parameter
+
+import io.archimedesfw.data.sql.criteria.Expressions
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class ArrayParameterTest {
+
+    @Test
+    fun `equals true`() {
+        val arr1 = Expressions.parameter(listOf<Int>(1,2,3))
+        val arr2 = Expressions.parameter(listOf<Int>(1,2,3))
+        Assertions.assertEquals(arr1, arr2)
+    }
+
+    @Test
+    fun `equals false`() {
+        val arr1 = Expressions.parameter(listOf<Int>(1,2,3))
+        val arr2 = Expressions.parameter(listOf<Int>(11,22,33))
+        Assertions.assertNotEquals(arr1, arr2)
+    }
+}


### PR DESCRIPTION
Before this change, ArrayParameter equality comparison always evaluated as false.
As a result, IN predicates also evaluated every equality comparison to false.
For this reason, it was impossible to mock properly any function that took IN predicates as an argument, because calls never matched with it.