### PR TITLE
feat: overload verifiedSpiedRun to take a VerificationMode arg

### DIFF
--- a/archimedes-usecase/src/test/kotlin/io/archimedesfw/usecase/UseCaseTestExtensions.kt
+++ b/archimedes-usecase/src/test/kotlin/io/archimedesfw/usecase/UseCaseTestExtensions.kt
@@ -7,6 +7,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.verification.VerificationMode
 
 fun <T : UseCase<R>, R> T.fakeRun(): R = this.execute()
 
@@ -41,5 +42,14 @@ fun <T : UseCase<*>, R> T.verifySpiedRun(toBeVerified: UseCase<R>): T {
                 " Before verify you have to prepare the spy with the 'asSpiedRun()' method "
     }
     verify(this).runInternal(toBeVerified)
+    return this
+}
+
+fun <T : UseCase<*>, R> T.verifySpiedRun(toBeVerified: UseCase<R>, mode: VerificationMode): T {
+    check(mockingDetails(this).isSpy) {
+        "This looks like a real object and not a spied UseCase." +
+                " Before verify you have to prepare the spy with the 'asSpiedRun()' method "
+    }
+    verify(this, mode).runInternal(toBeVerified)
     return this
 }


### PR DESCRIPTION
This changes adds an overload to make the use of `verifySpiedRun`  more similar to mockito's `verify`.

For example, it's not possible right now to check if a UseCase has **not** been called from the spied run (or called more than once). Now, it could be checked:
```kotlin
useCase.verifySpiedRun(otherUseCase, times(0))
```