### PR TITLE
feat/sql null comparisons

### DIFF
--- a/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/Predicates.kt
+++ b/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/Predicates.kt
@@ -11,6 +11,8 @@ import io.archimedesfw.data.sql.criteria.BinaryOperator.Companion.NE
 import io.archimedesfw.data.sql.criteria.Expressions.Companion.parameter
 import io.archimedesfw.data.sql.criteria.Expressions.Companion.parameterAny
 import io.archimedesfw.data.sql.criteria.Expressions.Companion.parameterArray
+import io.archimedesfw.data.sql.criteria.UnaryOperator.Companion.IS_NOT_NULL
+import io.archimedesfw.data.sql.criteria.UnaryOperator.Companion.IS_NULL
 import java.math.BigDecimal
 
 class Predicates {
@@ -21,6 +23,9 @@ class Predicates {
 
         fun <T> predicate(left: Expression<T>, operator: BinaryOperator, right: Expression<T>): Predicate =
             BinaryPredicate(left, operator, right)
+
+        fun <T> predicate(x: Expression<T>, operator: UnaryOperator): Predicate =
+            UnaryPredicate(x, operator)
 
         fun and(vararg predicate: Predicate): Predicate = and(predicate.asList())
         fun and(predicates: List<Predicate>): Predicate = AndPredicate(predicates)
@@ -57,6 +62,9 @@ class Predicates {
         inline fun ne(x: Expression<Long>, y: Long): Predicate = ne(x, parameter(y))
         inline fun ne(x: Expression<Short>, y: Short): Predicate = ne(x, parameter(y))
         inline fun ne(x: Expression<String>, y: String): Predicate = ne(x, parameter(y))
+
+        inline fun <T> isNull(x: Expression<T>): Predicate = predicate(x, IS_NULL)
+        inline fun <T> isNotNull(x: Expression<T>): Predicate = predicate(x, IS_NOT_NULL)
 
         // Comparisons for generic operands:
 

--- a/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/PredicatesExpressionExtensions.kt
+++ b/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/PredicatesExpressionExtensions.kt
@@ -32,6 +32,9 @@ inline fun Expression<Long>.ne(y: Long): Predicate = Predicates.ne(this, y)
 inline fun Expression<Short>.ne(y: Short): Predicate = Predicates.ne(this, y)
 inline fun Expression<String>.ne(y: String): Predicate = Predicates.ne(this, y)
 
+inline fun <T> Expression<T>.isNull(): Predicate = Predicates.isNull(this)
+inline fun <T> Expression<T>.isNotNull(): Predicate = Predicates.isNotNull(this)
+
 // Comparisons for generic operands:
 
 inline fun <T : Comparable<T>> Expression<T>.lt(y: Expression<T>): Predicate = Predicates.lt(this, y)

--- a/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/UnaryOperator.kt
+++ b/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/UnaryOperator.kt
@@ -1,0 +1,28 @@
+package io.archimedesfw.data.sql.criteria
+
+open class UnaryOperator(
+    val sql: String
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as UnaryOperator
+
+        if (sql != other.sql) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = sql.hashCode()
+
+    override fun toString(): String = "${this::class.simpleName}(sql='$sql')"
+
+    companion object {
+        // Generic operators
+        val IS_NULL: UnaryOperator = UnaryOperator(" IS NULL")
+        val IS_NOT_NULL: UnaryOperator = UnaryOperator(" IS NOT NULL")
+    }
+
+}

--- a/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/UnaryPredicate.kt
+++ b/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/UnaryPredicate.kt
@@ -1,0 +1,8 @@
+package io.archimedesfw.data.sql.criteria
+
+internal data class UnaryPredicate<T>(
+    val value: Expression<T>,
+    val operator: UnaryOperator
+) : Predicate {
+
+}

--- a/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlWhereBuilder.kt
+++ b/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlWhereBuilder.kt
@@ -1,14 +1,6 @@
 package io.archimedesfw.data.sql.criteria.builder
 
-import io.archimedesfw.data.sql.criteria.AndPredicate
-import io.archimedesfw.data.sql.criteria.BinaryPredicate
-import io.archimedesfw.data.sql.criteria.BinaryOperator
-import io.archimedesfw.data.sql.criteria.UnaryPredicate
-import io.archimedesfw.data.sql.criteria.UnaryOperator
-import io.archimedesfw.data.sql.criteria.CompoundPredicate
-import io.archimedesfw.data.sql.criteria.Expression
-import io.archimedesfw.data.sql.criteria.Predicate
-import io.archimedesfw.data.sql.criteria.SqlPredicate
+import io.archimedesfw.data.sql.criteria.*
 import io.archimedesfw.data.sql.criteria.parameter.ArrayParameter
 import io.archimedesfw.data.sql.criteria.parameter.Parameter
 import io.archimedesfw.data.sql.criteria.parameter.ParameterExpression
@@ -48,17 +40,9 @@ class SqlWhereBuilder {
             }
 
             is BinaryPredicate<*> -> {
-                val isNullRight = predicate.right is ParameterExpression && predicate.right.value == null
-
-                if (isNullRight && predicate.operator == BinaryOperator.EQ) {
-                    appendPredicate(sb, UnaryPredicate(predicate.left, UnaryOperator.IS_NULL), parameters)
-                } else if (isNullRight && predicate.operator == BinaryOperator.NE) {
-                    appendPredicate(sb, UnaryPredicate(predicate.left, UnaryOperator.IS_NOT_NULL), parameters)
-                } else {
-                    appendPredicate(sb, predicate.left, parameters)
-                    sb.append(predicate.operator.sql)
-                    appendPredicate(sb, predicate.right, parameters)
-                }
+                appendPredicate(sb, predicate.left, parameters)
+                sb.append(predicate.operator.sql)
+                appendPredicate(sb, predicate.right, parameters)
             }
 
             is UnaryPredicate<*> -> {

--- a/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/BookTable.kt
+++ b/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/BookTable.kt
@@ -4,7 +4,8 @@ internal class BookTable private constructor() : Table("book") {
     val id = column<Int>("id", isGenerated = true)
     val authorId = column<Int>("author_id")
     val title = column<String>("title")
-    val pagesCount = column<Int>("pages_count")
+    val pagesCount = column<Int?>("pages_count")
+
 
     internal companion object {
         internal val tBook = BookTable()

--- a/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/UnaryPredicateTest.kt
+++ b/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/UnaryPredicateTest.kt
@@ -1,0 +1,22 @@
+package io.archimedesfw.data.sql.criteria
+
+import io.archimedesfw.data.sql.criteria.UnaryOperator.Companion.IS_NULL
+import io.archimedesfw.data.sql.criteria.Expressions.Companion.expression
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Test
+
+internal class UnaryPredicateTest {
+
+    @Test
+    internal fun equals() {
+        val predicate1 = UnaryPredicate(expression<String>("a"), IS_NULL)
+        val predicate2 = UnaryPredicate(expression<String>("a"), IS_NULL)
+
+        assertNotSame(predicate1, predicate2)
+        assertEquals(predicate1, predicate2)
+    }
+
+}
+
+

--- a/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlWhereBuilderTest.kt
+++ b/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlWhereBuilderTest.kt
@@ -3,6 +3,7 @@ package io.archimedesfw.data.sql.criteria.builder
 import io.archimedesfw.data.sql.BookTable.Companion.tBook
 import io.archimedesfw.data.sql.criteria.Predicates.Companion.predicate
 import io.archimedesfw.data.sql.criteria.eq
+import io.archimedesfw.data.sql.criteria.ne
 import io.archimedesfw.data.sql.criteria.parameter.Parameter
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -45,6 +46,26 @@ internal class SqlWhereBuilderTest {
 
         assertEquals(" WHERE 1=1 AND false", sb.toString())
         assertTrue(parameters.isEmpty())
+    }
+
+    @Test
+    internal fun `build with null comparison`() {
+        where.predicates.add(tBook.pagesCount.eq(null))
+
+        whereBuilder.appendWhere(sb, where, parameters)
+
+        assertEquals(" WHERE book_.pages_count IS NULL", sb.toString())
+        assertEquals(emptyList<Parameter<*>>(), parameters.map { it.value })
+    }
+
+    @Test
+    internal fun `build with negative null comparison`() {
+        where.predicates.add(tBook.pagesCount.ne(null))
+
+        whereBuilder.appendWhere(sb, where, parameters)
+
+        assertEquals(" WHERE book_.pages_count IS NOT NULL", sb.toString())
+        assertEquals(emptyList<Parameter<*>>(), parameters.map { it.value })
     }
 
 }

--- a/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlWhereBuilderTest.kt
+++ b/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlWhereBuilderTest.kt
@@ -3,7 +3,6 @@ package io.archimedesfw.data.sql.criteria.builder
 import io.archimedesfw.data.sql.BookTable.Companion.tBook
 import io.archimedesfw.data.sql.criteria.Predicates.Companion.predicate
 import io.archimedesfw.data.sql.criteria.eq
-import io.archimedesfw.data.sql.criteria.ne
 import io.archimedesfw.data.sql.criteria.parameter.Parameter
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -46,26 +45,6 @@ internal class SqlWhereBuilderTest {
 
         assertEquals(" WHERE 1=1 AND false", sb.toString())
         assertTrue(parameters.isEmpty())
-    }
-
-    @Test
-    internal fun `build with null comparison`() {
-        where.predicates.add(tBook.pagesCount.eq(null))
-
-        whereBuilder.appendWhere(sb, where, parameters)
-
-        assertEquals(" WHERE book_.pages_count IS NULL", sb.toString())
-        assertEquals(emptyList<Parameter<*>>(), parameters.map { it.value })
-    }
-
-    @Test
-    internal fun `build with negative null comparison`() {
-        where.predicates.add(tBook.pagesCount.ne(null))
-
-        whereBuilder.appendWhere(sb, where, parameters)
-
-        assertEquals(" WHERE book_.pages_count IS NOT NULL", sb.toString())
-        assertEquals(emptyList<Parameter<*>>(), parameters.map { it.value })
     }
 
 }


### PR DESCRIPTION
Currently, a predicate checking a null value like `myColumn.eq(null)` translates to the following SQL: 
```sql
my_column = null
```
which is valid SQL, but doesn't actually check if `my_column` is null.

- I found out that `IS [NOT] NULL` is defined as a unary operator ([1](https://docs.oracle.com/cd/E14004_01/books/ToolsDevRef/operators_conditions8.html#:~:text=A%20unary%20operation%20is%20an,IS%20NULL%20evaluates%20to%20NULL.)) so I implemented the corresponding `UnaryOperator` class for them.
- I added a check on the `SqlWhereBuilder` to translate `EQ/NE` comparisons with a null value to a `IS_NULL/IS_NOT_NULL`.
- I added predicates and extensions to make the null checks too.