### PR TITLE
fix/valid-sql-for-empty-lists

### DIFF
--- a/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/parameter/ArrayParameter.kt
+++ b/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/parameter/ArrayParameter.kt
@@ -13,7 +13,9 @@ class ArrayParameter<T>(
     override val alias: String
         get() = throw UnsupportedOperationException("Cannot get alias of ${this::class.simpleName}.")
 
-    override val sql: String = parameters.joinToString(prefix = "(", postfix = ")") { "?" }
+    override val sql: String =
+        if (parameters.isNotEmpty()) parameters.joinToString(prefix = "(", postfix = ")") { "?" }
+        else "(null)"
 
     override fun set(ps: PreparedStatement, index: Int): Unit =
         throw UnsupportedOperationException("Cannot set PreparedStatement of ${this::class.simpleName}.")

--- a/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/parameter/ArrayParameterTest.kt
+++ b/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/parameter/ArrayParameterTest.kt
@@ -28,4 +28,10 @@ internal class ArrayParameterTest {
         val arr2 = Expressions.parameter(listOf<Int>(1, 2, 3))
         assertEquals(arr1.hashCode(), arr2.hashCode())
     }
+
+    @Test
+    fun `valid sql when empty`() {
+        val arr = Expressions.parameter(emptyList<Int>())
+        assertEquals("(null)", arr.sql)
+    }
 }


### PR DESCRIPTION
In case a dynamically built `ArrayParameter` is empty, the resulting SQL is not valid. For example:
```kotlin
val maybeEmpty = emptyList<Int>()
myColumn.`in`(maybeEmpty)
```
produces
```sql
my_column IN ()
```
which raises a SQL syntax error.

Maybe this case is expected to be handled before making it to the database, but I propose a solution based on this answer [SQL: Empty value list for the IN predicate (literals, not subqueries)](https://softwareengineering.stackexchange.com/a/438201), cited here:

> `IN ()` can be achieved with `IN (null)` as this is always false, even for null on the left hand side.