### PR TITLE
fix/single-column-updates

### DIFF
--- a/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlUpdateBuilder.kt
+++ b/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlUpdateBuilder.kt
@@ -32,22 +32,25 @@ class SqlUpdateBuilder(
         }
 
     private fun appendSet(sb: StringBuilder, columns: List<Column<*>>) {
-        sb.append(" SET (")
+        sb.append(" SET ")
+        if (columns.size > 1) sb.append("(")
         for (i in 0 until columns.lastIndex) {
             sb.append(columns[i].name)
             sb.append(',')
         }
         sb.append(columns[columns.lastIndex].name)
-        sb.append(") = ")
+        if (columns.size > 1) sb.append(")")
+        sb.append(" = ")
         appendDefaultValues(sb, columns)
     }
 
     private fun appendDefaultValues(sb: StringBuilder, columns: List<Column<*>>) {
-        sb.append('(')
+        if (columns.size > 1) sb.append('(')
         for (i in 0 until columns.lastIndex) {
             sb.append("?,")
         }
-        sb.append("?)")
+        sb.append("?")
+        if (columns.size > 1) sb.append(")")
     }
 
     private fun appendWhere(sb: StringBuilder, query: CriteriaUpdate, parameters: MutableList<Parameter<*>>) {

--- a/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/builder/SqUpdateBuilderTest.kt
+++ b/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/builder/SqUpdateBuilderTest.kt
@@ -21,8 +21,21 @@ internal class SqUpdateBuilderTest {
         assertEquals(SQL, sql.statement)
     }
 
+    @Test
+    fun `update single column in table`() {
+        val update = criteriaBuilder
+            .update(tAuthor)
+            .set(tAuthor.height)
+            .where(tAuthor.id.eq(1))
+
+        val sql = updateBuilder.toSql(update)
+
+        assertEquals(SQL_SINGLE_COLUMN, sql.statement)
+    }
+
     private companion object {
         private const val SQL = "UPDATE author AS author_ SET (name,height) = (?,?) WHERE author_.id=?"
+        private const val SQL_SINGLE_COLUMN = "UPDATE author AS author_ SET height = ? WHERE author_.id=?"
     }
 
 }


### PR DESCRIPTION
Currently, all updates follow the format:
```sql
UPDATE table SET (columnA, columnB) = (?, ?)
```
but single column updates like this one:
```sql
UPDATE table SET (columnA) = (?)
```
raise SQL syntax errors. 

Example from PostgreSQL:
```output
ERROR: source for a multiple-column UPDATE item must be a sub-SELECT or ROW() expression
```

So I added a check to avoid parenthesis in single column updates.