### PR TITLE
refactor: short-circuit the SQL update with one column

### DIFF
--- a/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlUpdateBuilder.kt
+++ b/archimedes-data-jdbc/src/main/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlUpdateBuilder.kt
@@ -32,25 +32,32 @@ class SqlUpdateBuilder(
         }
 
     private fun appendSet(sb: StringBuilder, columns: List<Column<*>>) {
-        sb.append(" SET ")
-        if (columns.size > 1) sb.append("(")
-        for (i in 0 until columns.lastIndex) {
+        val lastIndex = columns.lastIndex
+
+        if (columns.size == 1) {
+            sb.append(" SET ")
+            sb.append(columns[lastIndex].name)
+            sb.append(" = ?")
+            return
+        }
+
+        sb.append(" SET (")
+
+        for (i in 0 until lastIndex) {
             sb.append(columns[i].name)
             sb.append(',')
         }
-        sb.append(columns[columns.lastIndex].name)
-        if (columns.size > 1) sb.append(")")
-        sb.append(" = ")
+        sb.append(columns[lastIndex].name)
+
+        sb.append(") = (")
         appendDefaultValues(sb, columns)
     }
 
     private fun appendDefaultValues(sb: StringBuilder, columns: List<Column<*>>) {
-        if (columns.size > 1) sb.append('(')
         for (i in 0 until columns.lastIndex) {
             sb.append("?,")
         }
-        sb.append("?")
-        if (columns.size > 1) sb.append(")")
+        sb.append("?)")
     }
 
     private fun appendWhere(sb: StringBuilder, query: CriteriaUpdate, parameters: MutableList<Parameter<*>>) {

--- a/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlUpdateBuilderTest.kt
+++ b/archimedes-data-jdbc/src/test/kotlin/io/archimedesfw/data/sql/criteria/builder/SqlUpdateBuilderTest.kt
@@ -6,7 +6,7 @@ import io.archimedesfw.data.sql.criteria.eq
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-internal class SqUpdateBuilderTest {
+internal class SqlUpdateBuilderTest {
 
     private val criteriaBuilder = CriteriaBuilder()
     private val updateBuilder = SqlUpdateBuilder()
@@ -39,4 +39,3 @@ internal class SqUpdateBuilderTest {
     }
 
 }
-


### PR DESCRIPTION
Renamed SqUpdateBuilderTest to SqlUpdateBuilderTest for consistency with the class name. Optimized the appendSet method in SqlUpdateBuilder for single-column updates, reducing unnecessary checks and string manipulations.